### PR TITLE
Use newest available CC test-reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: Install CodeClimate Reporter
           command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.7.0-linux-amd64 > ./cc-test-reporter
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.9.0-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
       - run:


### PR DESCRIPTION
New binaries for 0.9.0 got uploaded, closing CodeClimate/test-reporter#449